### PR TITLE
Network interfaces different format

### DIFF
--- a/src/cadvisor/python/cadvisor.py
+++ b/src/cadvisor/python/cadvisor.py
@@ -374,6 +374,10 @@ class CAdvisor(object):
         metric_type = None
         type_instance = None
 
+        # In some occasions, the adapters might be wrapped in an "interfaces":{[...]} JSON object
+        if 'interfaces' in metrics.keys():
+            metrics = metrics['interfaces']
+
         #
         # the if_(dropped|packets|octets|errors) collectd types
         # expect the values to be compound in the form: rx:tx


### PR DESCRIPTION
The network interfaces might be wrapped inside an `"interfaces":{[...]}` JSON object.

This happened to us on a Ubuntu 14.04 based container.

Example:

```
{
  "interfaces":[
    {
      "tx_dropped":0,
      "rx_packets":605656,
      "name":"eth0",
      "rx_bytes":468460178,
      "tx_errors":0,
      "rx_errors":0,
      "tx_bytes":1875680896,
      "rx_dropped":8,
      "tx_packets":281385
    }
  ]
}
```
