### PR TITLE
Metrics keys and containers sliceId have different format

### DIFF
--- a/src/cadvisor/python/cadvisor.py
+++ b/src/cadvisor/python/cadvisor.py
@@ -608,6 +608,9 @@ class CAdvisor(object):
             self.set_container_slice_ids()
             for docker_container in self.docker_container_list:
                 if docker_container['SliceId']:
-                    self.output_metrics(''.join(docker_container['Names']).replace('/', ''), docker_container['Id'][0:12], metrics[docker_container['SliceId']][0])
 
+                    for key in metrics.keys():
+                        if docker_container['Id'] in key:
+                            self.output_metrics(''.join(docker_container['Names']).replace('/', ''), docker_container['Id'][0:12], metrics[key][0])
+                            break
 # END


### PR DESCRIPTION
Looks like SliceId not always equals metric key.
I had SliceId like `/system.slice/docker-91da...262.scope` format but metrics.keys() format was like `/docker/91da...262`. As a result, I get KeyError exception. 
Now we always will use correct key
